### PR TITLE
Do not check `limactl list` exit code

### DIFF
--- a/lib/cli_helper.rb
+++ b/lib/cli_helper.rb
@@ -40,10 +40,7 @@ module Lima
 
     def list(vm_names = [])
       lima_cmd = [@limactl, 'list', '--json'] + vm_names
-      stdout_str, stderr_str, status = Open3.capture3(*lima_cmd)
-      unless status.success?
-        raise LimaError, "`#{lima_cmd.join(' ')}` failed with status #{status.exitstatus}: #{stderr_str}"
-      end
+      stdout_str, _stderr_str, _status = Open3.capture3(*lima_cmd)
 
       stdout_str.split("\n").map { |vm| JSON.parse(vm) }
     end
@@ -51,10 +48,7 @@ module Lima
     # A bit faster `list` variant to check the VM status
     def status(vm_name)
       lima_cmd = [@limactl, 'list', '--format', '{{ .Status }}', vm_name]
-      stdout_str, stderr_str, status = Open3.capture3(*lima_cmd)
-      unless status.success?
-        raise LimaError, "`#{lima_cmd.join(' ')}` failed with status #{status.exitstatus}: #{stderr_str}"
-      end
+      stdout_str, _stderr_str, _status = Open3.capture3(*lima_cmd)
 
       stdout_str.chomp
     end


### PR DESCRIPTION
Starting from lima v0.22.0 (I guess) `limactl ls <vm>` returns 1, when the <vm> doesn't exist. That breaks many plans because list and status tasks fails instead of returning empty result.

This commit removes the `limactl list` return code check. Maybe later we can improve it.

Fixes #31